### PR TITLE
adding the ability to add non-breaking nodes to an existing graph

### DIFF
--- a/lib/journey.ex
+++ b/lib/journey.ex
@@ -862,7 +862,8 @@ defmodule Journey do
     Journey.Executions.create_new(
       graph.name,
       graph.version,
-      graph.nodes
+      graph.nodes,
+      graph.hash
     )
     |> Journey.Scheduler.advance()
   end

--- a/lib/journey/executions.ex
+++ b/lib/journey/executions.ex
@@ -6,13 +6,17 @@ defmodule Journey.Executions do
   require Logger
   import Journey.Helpers.Log
 
-  def create_new(graph_name, graph_version, nodes) do
+  # Namespace for PostgreSQL advisory locks used in graph migrations
+  @migration_lock_namespace 12_345
+
+  def create_new(graph_name, graph_version, nodes, graph_hash) do
     {:ok, execution} =
       Journey.Repo.transaction(fn repo ->
         execution =
           %Execution{
             graph_name: graph_name,
             graph_version: graph_version,
+            graph_hash: graph_hash,
             revision: 0
           }
           |> repo.insert!()
@@ -853,5 +857,115 @@ defmodule Journey.Executions do
       :asc
     )
     |> Enum.map(fn h -> Map.delete(h, :revision_at_start) end)
+  end
+
+  def migrate_to_current_graph_if_needed(execution, graph) do
+    if execution.graph_hash == graph.hash do
+      # Hashes match, no migration needed
+      execution
+    else
+      # Execution has no hash (old execution) or hashes differ, migrate
+      migrate_to_current_graph(execution, graph)
+    end
+  end
+
+  defp migrate_to_current_graph(execution, graph) do
+    {:ok, migrated_execution} =
+      Journey.Repo.transaction(fn repo ->
+        # Acquire advisory lock to prevent concurrent migrations of the same execution
+        lock_key = :erlang.phash2(execution.id)
+        repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [@migration_lock_namespace, lock_key])
+
+        # Reload execution after acquiring lock to get the latest state
+        current_execution = load_execution_for_migration(repo, execution.id)
+
+        # Check if migration is still needed (another process might have just done it)
+        if current_execution.graph_hash == graph.hash do
+          # Already migrated by another process
+          current_execution
+        else
+          # Proceed with migration
+          perform_migration(repo, execution.id, current_execution, graph)
+        end
+      end)
+
+    migrated_execution
+  end
+
+  defp perform_migration(repo, execution_id, current_execution, graph) do
+    # Find missing nodes
+    missing_node_names = find_missing_nodes(current_execution, graph)
+
+    # Add missing nodes if any
+    if MapSet.size(missing_node_names) > 0 do
+      add_missing_nodes(repo, execution_id, current_execution.revision, graph, missing_node_names)
+    end
+
+    # Update execution's graph_hash
+    from(e in Execution, where: e.id == ^execution_id)
+    |> repo.update_all(set: [graph_hash: graph.hash])
+
+    # Reload and return the migrated execution
+    load(execution_id, true, false)
+  end
+
+  defp load_execution_for_migration(repo, execution_id) do
+    from(e in Execution,
+      where: e.id == ^execution_id,
+      preload: [:values, :computations]
+    )
+    |> repo.one!()
+    |> convert_node_names_to_atoms()
+  end
+
+  defp find_missing_nodes(current_execution, graph) do
+    # Get current node names from execution
+    existing_node_names =
+      current_execution.values
+      |> Enum.map(& &1.node_name)
+      |> MapSet.new()
+
+    # Get expected node names from graph
+    expected_node_names =
+      graph.nodes
+      |> Enum.map(& &1.name)
+      |> MapSet.new()
+
+    # Find missing nodes (as atoms)
+    MapSet.difference(expected_node_names, existing_node_names)
+  end
+
+  defp add_missing_nodes(repo, execution_id, revision, graph, missing_node_names) do
+    graph.nodes
+    |> Enum.filter(fn node ->
+      MapSet.member?(missing_node_names, node.name)
+    end)
+    |> Enum.each(fn graph_node ->
+      add_node_records(repo, execution_id, revision, graph_node)
+    end)
+  end
+
+  defp add_node_records(repo, execution_id, _revision, graph_node) do
+    # Create value record with ex_revision: 0 for new nodes
+    %Execution.Value{
+      execution_id: execution_id,
+      node_name: Atom.to_string(graph_node.name),
+      node_type: graph_node.type,
+      ex_revision: 0,
+      set_time: nil,
+      node_value: nil
+    }
+    |> repo.insert!()
+
+    # If it's a compute node, also create a computation record
+    if graph_node.type in Execution.ComputationType.values() do
+      %Execution.Computation{
+        execution_id: execution_id,
+        node_name: Atom.to_string(graph_node.name),
+        computation_type: graph_node.type,
+        state: :not_set
+      }
+      |> repo.insert!()
+    end
   end
 end

--- a/lib/journey/graph.ex
+++ b/lib/journey/graph.ex
@@ -3,8 +3,15 @@ defmodule Journey.Graph do
 
   import Journey.Node, only: [input: 1]
 
-  defstruct [:name, :version, :nodes, :f_on_save]
-  @type t :: %__MODULE__{name: String.t(), nodes: list, f_on_save: function() | nil}
+  defstruct [:name, :version, :nodes, :f_on_save, :hash]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          version: String.t(),
+          nodes: list,
+          f_on_save: function() | nil,
+          hash: String.t()
+        }
 
   def new(name, version, nodes, opts \\ [])
       when is_binary(name) and is_binary(version) and is_list(nodes) do
@@ -19,11 +26,14 @@ defmodule Journey.Graph do
 
     KeywordValidator.validate!(opts, opts_schema)
 
+    all_nodes = [input(:execution_id), input(:last_updated_at)] ++ nodes
+
     %__MODULE__{
       name: name,
       version: version,
-      nodes: [input(:execution_id), input(:last_updated_at)] ++ nodes,
-      f_on_save: Keyword.get(opts, :f_on_save)
+      nodes: all_nodes,
+      f_on_save: Keyword.get(opts, :f_on_save),
+      hash: compute_hash(all_nodes)
     }
   end
 
@@ -34,5 +44,26 @@ defmodule Journey.Graph do
   def find_node_by_name(graph, node_name) when is_struct(graph, Journey.Graph) and is_atom(node_name) do
     graph.nodes
     |> Enum.find(fn n -> n.name == node_name end)
+  end
+
+  defp compute_hash(nodes) do
+    nodes
+    |> Enum.sort_by(& &1.name)
+    |> Enum.map(&extract_hash_components/1)
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16()
+  end
+
+  defp extract_hash_components(node) do
+    base_components = {node.name, node.type}
+
+    case node do
+      %{gated_by: gated_by} ->
+        {base_components, gated_by}
+
+      _ ->
+        base_components
+    end
   end
 end

--- a/lib/journey/persistence/schema/execution.ex
+++ b/lib/journey/persistence/schema/execution.ex
@@ -8,6 +8,7 @@ defmodule Journey.Persistence.Schema.Execution do
   schema "executions" do
     field(:graph_name, :string)
     field(:graph_version, :string)
+    field(:graph_hash, :string)
     field(:archived_at, :integer, default: nil)
     has_many(:values, Journey.Persistence.Schema.Execution.Value, preload_order: [desc: :ex_revision])
 

--- a/lib/journey/scheduler.ex
+++ b/lib/journey/scheduler.ex
@@ -14,7 +14,14 @@ defmodule Journey.Scheduler do
   def advance(execution) do
     prefix = "[#{execution.id}] [#{mf()}] [#{inspect(self())}]"
     Logger.debug("#{prefix}: starting")
-    advance_with_graph(prefix, execution, Journey.Graph.Catalog.fetch(execution.graph_name, execution.graph_version))
+
+    # Migrate execution to current graph if needed
+    execution = Journey.Executions.migrate_to_current_graph_if_needed(execution)
+
+    # Fetch graph again after potential migration (execution may have updated graph version)
+    graph = Journey.Graph.Catalog.fetch(execution.graph_name, execution.graph_version)
+
+    advance_with_graph(prefix, execution, graph)
   end
 
   defp advance_with_graph(prefix, execution, nil) do

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Journey.MixProject do
       ],
       test_coverage: [
         summary: [
-          threshold: 79
+          threshold: 81
         ]
       ],
       deps: deps()

--- a/priv/repo/migrations/20250825192107_add_graph_hash_to_executions.exs
+++ b/priv/repo/migrations/20250825192107_add_graph_hash_to_executions.exs
@@ -1,0 +1,9 @@
+defmodule Journey.Repo.Migrations.AddGraphHashToExecutions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:executions) do
+      add(:graph_hash, :string)
+    end
+  end
+end

--- a/test/journey/executions_migration_test.exs
+++ b/test/journey/executions_migration_test.exs
@@ -44,7 +44,7 @@ defmodule Journey.ExecutionsMigrationTest do
       assert original_hash != updated_graph.hash
 
       # Perform migration
-      migrated_execution = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+      migrated_execution = Journey.Executions.migrate_to_current_graph_if_needed(execution)
 
       # Verify migration results
       assert migrated_execution.id == execution.id
@@ -90,11 +90,11 @@ defmodule Journey.ExecutionsMigrationTest do
         )
 
       # First migration
-      migrated_once = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+      migrated_once = Journey.Executions.migrate_to_current_graph_if_needed(execution)
       assert migrated_once.graph_hash == updated_graph.hash
 
       # Second migration (should be no-op)
-      migrated_twice = Journey.Executions.migrate_to_current_graph_if_needed(migrated_once, updated_graph)
+      migrated_twice = Journey.Executions.migrate_to_current_graph_if_needed(migrated_once)
       assert migrated_twice.graph_hash == updated_graph.hash
       assert migrated_twice.id == migrated_once.id
 
@@ -117,7 +117,7 @@ defmodule Journey.ExecutionsMigrationTest do
       original_hash = execution.graph_hash
 
       # Call migrate with same graph (same hash)
-      result = Journey.Executions.migrate_to_current_graph_if_needed(execution, graph)
+      result = Journey.Executions.migrate_to_current_graph_if_needed(execution)
 
       # Should return same execution object (no migration)
       assert result == execution
@@ -139,7 +139,7 @@ defmodule Journey.ExecutionsMigrationTest do
       execution = Journey.set_value(execution, :user_id, 123)
 
       # Updated graph with various node types
-      updated_graph =
+      _updated_graph =
         Journey.new_graph(
           "complex_migration_test",
           "v1",
@@ -157,7 +157,7 @@ defmodule Journey.ExecutionsMigrationTest do
         )
 
       # Perform migration
-      migrated = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+      migrated = Journey.Executions.migrate_to_current_graph_if_needed(execution)
 
       # Check all nodes exist
       assert {:ok, 123} == Journey.get_value(migrated, :user_id)
@@ -188,7 +188,7 @@ defmodule Journey.ExecutionsMigrationTest do
       assert execution.revision > 0
 
       # Create updated graph with new node
-      updated_graph =
+      _updated_graph =
         Journey.new_graph(
           "ex_revision_test",
           "v1",
@@ -196,7 +196,7 @@ defmodule Journey.ExecutionsMigrationTest do
         )
 
       # Perform migration
-      migrated = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+      migrated = Journey.Executions.migrate_to_current_graph_if_needed(execution)
 
       # Find the new node's value record
       new_node_value = Journey.Executions.find_value_by_name(migrated, :new_node)
@@ -238,7 +238,7 @@ defmodule Journey.ExecutionsMigrationTest do
       results =
         for _i <- 1..5 do
           Task.async(fn ->
-            Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+            Journey.Executions.migrate_to_current_graph_if_needed(execution)
           end)
         end
         |> Task.await_many(5000)

--- a/test/journey/executions_migration_test.exs
+++ b/test/journey/executions_migration_test.exs
@@ -1,0 +1,278 @@
+defmodule Journey.ExecutionsMigrationTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Node
+  import Ecto.Query
+
+  describe "migrate_to_current_graph_if_needed/2" do
+    test "sunny-day migration: adds new nodes when graph is updated" do
+      # Create original graph with two input nodes
+      original_graph =
+        Journey.new_graph(
+          "migration_test_graph",
+          "v1",
+          [
+            input(:name),
+            input(:age)
+          ]
+        )
+
+      # Start execution with original graph
+      execution = Journey.start_execution(original_graph)
+      execution = Journey.set_value(execution, :name, "Alice")
+      execution = Journey.set_value(execution, :age, 30)
+
+      # Verify initial state
+      assert {:ok, "Alice"} == Journey.get_value(execution, :name)
+      assert {:ok, 30} == Journey.get_value(execution, :age)
+      original_hash = execution.graph_hash
+
+      # Create updated graph with additional nodes
+      updated_graph =
+        Journey.new_graph(
+          "migration_test_graph",
+          "v1",
+          [
+            input(:name),
+            input(:age),
+            input(:email),
+            compute(:greeting, [:name], fn %{name: name} -> {:ok, "Hello, #{name}!"} end)
+          ]
+        )
+
+      # Verify the graphs have different hashes
+      assert original_hash != updated_graph.hash
+
+      # Perform migration
+      migrated_execution = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+
+      # Verify migration results
+      assert migrated_execution.id == execution.id
+      assert migrated_execution.graph_hash == updated_graph.hash
+
+      # Original values should be preserved
+      assert {:ok, "Alice"} == Journey.get_value(migrated_execution, :name)
+      assert {:ok, 30} == Journey.get_value(migrated_execution, :age)
+
+      # New input node should exist but be unset
+      assert {:error, :not_set} == Journey.get_value(migrated_execution, :email)
+
+      # New compute node should exist but be unset (until triggered)
+      assert {:error, :not_set} == Journey.get_value(migrated_execution, :greeting)
+
+      # Verify we can set the new input node
+      migrated_execution = Journey.set_value(migrated_execution, :email, "alice@example.com")
+      assert {:ok, "alice@example.com"} == Journey.get_value(migrated_execution, :email)
+
+      # Verify the compute node works (it should compute since :name is already set)
+      assert {:ok, "Hello, Alice!"} == Journey.get_value(migrated_execution, :greeting, wait_any: true)
+    end
+
+    test "migration is idempotent" do
+      # Create original graph
+      original_graph =
+        Journey.new_graph(
+          "idempotent_test_graph",
+          "v1",
+          [input(:a)]
+        )
+
+      # Start execution
+      execution = Journey.start_execution(original_graph)
+      execution = Journey.set_value(execution, :a, "value_a")
+
+      # Create updated graph
+      updated_graph =
+        Journey.new_graph(
+          "idempotent_test_graph",
+          "v1",
+          [input(:a), input(:b)]
+        )
+
+      # First migration
+      migrated_once = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+      assert migrated_once.graph_hash == updated_graph.hash
+
+      # Second migration (should be no-op)
+      migrated_twice = Journey.Executions.migrate_to_current_graph_if_needed(migrated_once, updated_graph)
+      assert migrated_twice.graph_hash == updated_graph.hash
+      assert migrated_twice.id == migrated_once.id
+
+      # Values should remain the same
+      assert {:ok, "value_a"} == Journey.get_value(migrated_twice, :a)
+      assert {:error, :not_set} == Journey.get_value(migrated_twice, :b)
+    end
+
+    test "no migration when hashes match" do
+      # Create graph
+      graph =
+        Journey.new_graph(
+          "no_migration_test",
+          "v1",
+          [input(:x), input(:y)]
+        )
+
+      # Start execution
+      execution = Journey.start_execution(graph)
+      original_hash = execution.graph_hash
+
+      # Call migrate with same graph (same hash)
+      result = Journey.Executions.migrate_to_current_graph_if_needed(execution, graph)
+
+      # Should return same execution object (no migration)
+      assert result == execution
+      assert result.graph_hash == original_hash
+    end
+
+    test "migration handles complex node types" do
+      # Original graph with just input
+      original_graph =
+        Journey.new_graph(
+          "complex_migration_test",
+          "v1",
+          [
+            input(:user_id)
+          ]
+        )
+
+      execution = Journey.start_execution(original_graph)
+      execution = Journey.set_value(execution, :user_id, 123)
+
+      # Updated graph with various node types
+      updated_graph =
+        Journey.new_graph(
+          "complex_migration_test",
+          "v1",
+          [
+            input(:user_id),
+            input(:user_name),
+            compute(:user_greeting, [:user_name], fn %{user_name: name} -> {:ok, "Welcome, #{name}"} end),
+            mutate(
+              :clear_user_id,
+              [:user_greeting],
+              fn _ -> {:ok, nil} end,
+              mutates: :user_id
+            )
+          ]
+        )
+
+      # Perform migration
+      migrated = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+
+      # Check all nodes exist
+      assert {:ok, 123} == Journey.get_value(migrated, :user_id)
+      assert {:error, :not_set} == Journey.get_value(migrated, :user_name)
+      assert {:error, :not_set} == Journey.get_value(migrated, :user_greeting)
+      assert {:error, :not_set} == Journey.get_value(migrated, :clear_user_id)
+
+      # Verify the nodes can be used
+      migrated = Journey.set_value(migrated, :user_name, "Bob")
+      assert {:ok, "Welcome, Bob"} == Journey.get_value(migrated, :user_greeting, wait_any: true)
+    end
+
+    test "new nodes start with ex_revision 0" do
+      # Create original graph
+      original_graph =
+        Journey.new_graph(
+          "ex_revision_test",
+          "v1",
+          [input(:original_node)]
+        )
+
+      # Start execution and set some values to increase revision
+      execution = Journey.start_execution(original_graph)
+      execution = Journey.set_value(execution, :original_node, "value1")
+      execution = Journey.set_value(execution, :original_node, "value2")
+
+      # Verify execution has a higher revision
+      assert execution.revision > 0
+
+      # Create updated graph with new node
+      updated_graph =
+        Journey.new_graph(
+          "ex_revision_test",
+          "v1",
+          [input(:original_node), input(:new_node)]
+        )
+
+      # Perform migration
+      migrated = Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+
+      # Find the new node's value record
+      new_node_value = Journey.Executions.find_value_by_name(migrated, :new_node)
+
+      # New node should have ex_revision: 0
+      assert new_node_value.ex_revision == 0
+      assert new_node_value.set_time == nil
+      assert new_node_value.node_value == nil
+
+      # Original node should maintain its revision
+      original_node_value = Journey.Executions.find_value_by_name(migrated, :original_node)
+      assert original_node_value.ex_revision > 0
+    end
+
+    test "concurrent migrations are handled safely" do
+      # This test verifies that advisory locks prevent race conditions
+      # We can't easily simulate true concurrency in tests, but we can verify
+      # that repeated migrations don't cause issues
+
+      original_graph =
+        Journey.new_graph(
+          "concurrent_test",
+          "v1",
+          [input(:base)]
+        )
+
+      execution = Journey.start_execution(original_graph)
+      execution = Journey.set_value(execution, :base, "base_value")
+
+      updated_graph =
+        Journey.new_graph(
+          "concurrent_test",
+          "v1",
+          [input(:base), input(:new1), input(:new2)]
+        )
+
+      # Perform migration multiple times rapidly
+      # This should be safe due to advisory locks and hash checking
+      results =
+        for _i <- 1..5 do
+          Task.async(fn ->
+            Journey.Executions.migrate_to_current_graph_if_needed(execution, updated_graph)
+          end)
+        end
+        |> Task.await_many(5000)
+
+      # All results should have the same structure
+      first_result = hd(results)
+
+      for result <- results do
+        assert result.id == first_result.id
+        assert result.graph_hash == updated_graph.hash
+        assert {:ok, "base_value"} == Journey.get_value(result, :base)
+        assert {:error, :not_set} == Journey.get_value(result, :new1)
+        assert {:error, :not_set} == Journey.get_value(result, :new2)
+      end
+
+      # Verify no duplicate value records were created by checking the database
+      alias Journey.Persistence.Schema.Execution.Value
+
+      value_counts =
+        from(v in Value,
+          where: v.execution_id == ^execution.id,
+          group_by: v.node_name,
+          select: {v.node_name, count(v.id)}
+        )
+        |> Journey.Repo.all()
+        |> Enum.into(%{})
+
+      # Each node should have exactly one value record
+      expected_nodes = ["execution_id", "last_updated_at", "base", "new1", "new2"]
+
+      for node_name <- expected_nodes do
+        assert value_counts[node_name] == 1,
+               "Node #{node_name} has #{value_counts[node_name]} value records, expected 1"
+      end
+    end
+  end
+end

--- a/test/journey/graph_hash_test.exs
+++ b/test/journey/graph_hash_test.exs
@@ -1,0 +1,459 @@
+defmodule Journey.GraphHashTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Node
+
+  describe "graph hash computation" do
+    test "generates consistent hash for same graph structure" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      assert graph1.hash == graph2.hash
+    end
+
+    test "generates different hash when nodes are added" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            input(:c)
+          ]
+        )
+
+      assert graph1.hash != graph2.hash
+    end
+
+    test "generates different hash when node types change" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            compute(:a, [], fn _ -> {:ok, "value"} end)
+          ]
+        )
+
+      assert graph1.hash != graph2.hash
+    end
+
+    test "generates different hash when compute dependencies change" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(:c, [:a], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash is consistent regardless of node order" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:b),
+            input(:a),
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end),
+            input(:b),
+            input(:a)
+          ]
+        )
+
+      assert graph1.hash == graph2.hash
+    end
+  end
+
+  describe "complex gated_by conditions" do
+    test "hash differs with :or vs simple list dependencies" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(
+              :c,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :or,
+                [{:a, &Journey.Node.Conditions.provided?/1}, {:b, &Journey.Node.Conditions.provided?/1}]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash differs with :and conditions" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(:c, [:a, :b], fn _ -> {:ok, "result"} end)
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(
+              :c,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :and,
+                [{:a, &Journey.Node.Conditions.provided?/1}, {:b, &Journey.Node.Conditions.provided?/1}]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      # :and with predicates is different from simple list
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash differs with :not conditions" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(
+              :c,
+              Journey.Node.UpstreamDependencies.unblocked_when({:a, &Journey.Node.Conditions.provided?/1}),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(
+              :c,
+              Journey.Node.UpstreamDependencies.unblocked_when({:not, {:a, &Journey.Node.Conditions.provided?/1}}),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash differs with nested :and/:or conditions" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:g1_a),
+            input(:g1_b),
+            input(:g2_a),
+            input(:g2_b),
+            compute(
+              :result,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :and,
+                [
+                  {:or, [{:g1_a, &Journey.Node.Conditions.provided?/1}, {:g1_b, &Journey.Node.Conditions.provided?/1}]},
+                  {:or, [{:g2_a, &Journey.Node.Conditions.provided?/1}, {:g2_b, &Journey.Node.Conditions.provided?/1}]}
+                ]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:g1_a),
+            input(:g1_b),
+            input(:g2_a),
+            input(:g2_b),
+            compute(
+              :result,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :or,
+                [
+                  {:and,
+                   [{:g1_a, &Journey.Node.Conditions.provided?/1}, {:g1_b, &Journey.Node.Conditions.provided?/1}]},
+                  {:and, [{:g2_a, &Journey.Node.Conditions.provided?/1}, {:g2_b, &Journey.Node.Conditions.provided?/1}]}
+                ]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      # Different nesting structure should produce different hash
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash differs with deeply nested conditions" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            input(:c),
+            input(:d),
+            compute(
+              :result,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :and,
+                [
+                  {:or, [{:a, &Journey.Node.Conditions.provided?/1}, {:b, &Journey.Node.Conditions.provided?/1}]},
+                  {:and, [{:c, &Journey.Node.Conditions.provided?/1}, {:d, &Journey.Node.Conditions.provided?/1}]}
+                ]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            input(:c),
+            input(:d),
+            compute(
+              :result,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :or,
+                [
+                  {:and, [{:a, &Journey.Node.Conditions.provided?/1}, {:c, &Journey.Node.Conditions.provided?/1}]},
+                  {:and, [{:b, &Journey.Node.Conditions.provided?/1}, {:d, &Journey.Node.Conditions.provided?/1}]}
+                ]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      # Different nested structure should produce different hash
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash differs when condition order changes" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(
+              :c,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :or,
+                [{:a, &Journey.Node.Conditions.provided?/1}, {:b, &Journey.Node.Conditions.provided?/1}]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            input(:b),
+            compute(
+              :c,
+              Journey.Node.UpstreamDependencies.unblocked_when({
+                :or,
+                [{:b, &Journey.Node.Conditions.provided?/1}, {:a, &Journey.Node.Conditions.provided?/1}]
+              }),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      # Order of conditions is part of the graph structure, so hashes differ
+      assert graph1.hash != graph2.hash
+    end
+
+    test "hash differs with different predicates" do
+      defmodule TestPredicates do
+        def always_true(_), do: true
+        def always_false(_), do: false
+      end
+
+      graph1 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            compute(
+              :b,
+              Journey.Node.UpstreamDependencies.unblocked_when({:a, &Journey.Node.Conditions.provided?/1}),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph",
+          "v1",
+          [
+            input(:a),
+            compute(
+              :b,
+              Journey.Node.UpstreamDependencies.unblocked_when({:a, &TestPredicates.always_true/1}),
+              fn _ -> {:ok, "result"} end
+            )
+          ]
+        )
+
+      # Different predicates should produce different hashes
+      assert graph1.hash != graph2.hash
+    end
+  end
+
+  describe "hash propagation to executions" do
+    test "execution receives graph hash when created" do
+      graph =
+        Journey.new_graph(
+          "test_graph_for_execution",
+          "v1",
+          [
+            input(:a),
+            input(:b)
+          ]
+        )
+
+      execution = Journey.start_execution(graph)
+
+      assert execution.graph_hash == graph.hash
+      assert is_binary(execution.graph_hash)
+      # SHA256 in hex
+      assert String.length(execution.graph_hash) == 64
+    end
+
+    test "different graphs produce executions with different hashes" do
+      graph1 =
+        Journey.new_graph(
+          "test_graph_1",
+          "v1",
+          [input(:a)]
+        )
+
+      graph2 =
+        Journey.new_graph(
+          "test_graph_2",
+          "v1",
+          [input(:a), input(:b)]
+        )
+
+      execution1 = Journey.start_execution(graph1)
+      execution2 = Journey.start_execution(graph2)
+
+      assert execution1.graph_hash != execution2.graph_hash
+    end
+  end
+end


### PR DESCRIPTION
a code fragment from a test:
```elixir
      original_graph =
        Journey.new_graph(
          "idempotent_test_graph",
          "v1",
          [input(:a)]
        )

      # Start execution
      execution = Journey.start_execution(original_graph)
      execution = Journey.set_value(execution, :a, "value_a")

      # Create updated graph
      updated_graph =
        Journey.new_graph(
          "idempotent_test_graph",
          "v1",
          [input(:a), input(:b)]
        )
```

the execution created with the old graph will continue to be operational even after the graph gets enhanced with new non-breaking nodes. e.g.

```elixir
      execution = Journey.set_value(execution, :b, "value_b")
```
this now works seamlessly.