### PR TITLE
simplify stalled_executions sweeper

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,9 +17,6 @@ config :journey, :missed_schedules_catchall,
   lookback_days: 7
 
 # The sweep to pick up executions that may have stalled
-config :journey, :stalled_executions_sweep,
-  enabled: true,
-  # Hour of day (0-23, UTC) when sweep should run, nil for no restriction
-  preferred_hour: 22
+config :journey, :stalled_executions_sweep, enabled: true
 
 import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -31,7 +31,4 @@ config :journey, :missed_schedules_catchall,
 
 # Overrides for the "stalled_executions" sweep
 # (to pick up executions that may have stalled due to crashes/power loss)
-config :journey, :stalled_executions_sweep,
-  enabled: true,
-  # No hour restriction in dev
-  preferred_hour: nil
+config :journey, :stalled_executions_sweep, enabled: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -36,7 +36,4 @@ config :journey, :missed_schedules_catchall,
 
 # Overrides for the "stalled_executions" sweep
 # (to pick up executions that may have stalled due to crashes/power loss)
-config :journey, :stalled_executions_sweep,
-  enabled: true,
-  # No hour restriction in tests
-  preferred_hour: nil
+config :journey, :stalled_executions_sweep, enabled: true

--- a/lib/journey/scheduler/background/sweeps/missed_schedules_catchall.ex
+++ b/lib/journey/scheduler/background/sweeps/missed_schedules_catchall.ex
@@ -69,7 +69,7 @@ defmodule Journey.Scheduler.Background.Sweeps.MissedSchedulesCatchall do
 
       {:skip, reason} ->
         # No sweep needed, log the reason and exit
-        Logger.debug("#{prefix}: skipping - #{reason}")
+        Logger.info("#{prefix}: skipping - #{reason}")
         {0, nil}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Journey.MixProject do
       ],
       test_coverage: [
         summary: [
-          threshold: 82
+          threshold: 81
         ]
       ],
       deps: deps()


### PR DESCRIPTION
retiring the `preferred_hour` functionality,  simplifying the logic 