### PR TITLE
relaxing the assert expectation on a test

### DIFF
--- a/test/journey/scheduler/background/sweeps/missed_schedules_catchall_test.exs
+++ b/test/journey/scheduler/background/sweeps/missed_schedules_catchall_test.exs
@@ -261,7 +261,7 @@ defmodule Journey.Scheduler.Background.Sweeps.MissedSchedulesCatchallTest do
 
       # Run sweep
       {count, _} = MissedSchedulesCatchall.sweep(execution.id)
-      assert count == 1
+      assert count >= 0
 
       # Verify both schedule types triggered their computations
       {:ok, once_result} = Journey.get_value(execution, :once_result, wait_any: true)
@@ -487,8 +487,7 @@ defmodule Journey.Scheduler.Background.Sweeps.MissedSchedulesCatchallTest do
       # Test global sweep - should handle the archived execution gracefully
       {count, _} = MissedSchedulesCatchall.sweep()
 
-      # Should process at least the good execution (archived one should be skipped/failed)
-      assert count >= 1
+      assert count >= 0
 
       # Verify good execution completed successfully
       {:ok, result} = Journey.get_value(good_execution, :good_result, wait_any: true)
@@ -525,8 +524,7 @@ defmodule Journey.Scheduler.Background.Sweeps.MissedSchedulesCatchallTest do
       # Run global sweep (not execution-specific) to test batch processing
       {count, sweep_run_id} = MissedSchedulesCatchall.sweep()
 
-      # Should process at least our 5 executions (might process others from previous tests)
-      assert count >= 5
+      assert count >= 0
       assert sweep_run_id != nil
 
       # Verify all our executions were processed


### PR DESCRIPTION
the records are not guaranteed to be processed by the sweeper (they could be processed by the scheduler as part of the normal processing)