### PR TITLE
fully implementing reactive behavior for :or recomputations

### DIFF
--- a/lib/journey/scheduler/recompute.ex
+++ b/lib/journey/scheduler/recompute.ex
@@ -22,7 +22,7 @@ defmodule Journey.Scheduler.Recompute do
           from(c in Computation,
             where:
               c.execution_id == ^execution.id and
-                c.computation_type in [:compute, :mutate, :schedule_once] and c.state != ^:not_set,
+                c.computation_type in [:compute, :mutate, :schedule_once] and c.state == ^:success,
             order_by: [desc: c.ex_revision_at_start],
             distinct: c.node_name,
             select: c.id

--- a/lib/journey/scheduler/recompute.ex
+++ b/lib/journey/scheduler/recompute.ex
@@ -76,39 +76,53 @@ defmodule Journey.Scheduler.Recompute do
   end
 
   defp an_upstream_node_has_a_newer_version?(computation, graph, all_values) do
-    gated_by =
-      graph
-      |> Graph.find_node_by_name(computation.node_name)
-      |> Map.get(:gated_by)
-      |> Journey.Node.UpstreamDependencies.Computations.list_all_node_names()
+    graph_node = Graph.find_node_by_name(graph, computation.node_name)
 
-    current_node_revisions =
-      all_values
-      |> Enum.filter(fn %{node_name: node_name} -> node_name in gated_by end)
-      |> Enum.map(fn %{node_name: node_name} = node -> {node_name, node.ex_revision} end)
-      |> Enum.into(%{})
+    # Evaluate which conditions are currently met
+    readiness_result =
+      Journey.Node.UpstreamDependencies.Computations.evaluate_computation_for_readiness(
+        all_values,
+        graph_node.gated_by
+      )
 
-    computed_with_node_revisions =
-      computation.computed_with
-      |> case do
-        nil ->
-          %{}
+    if readiness_result.ready? do
+      # Extract nodes whose conditions are currently satisfied
+      current_node_revisions =
+        readiness_result.conditions_met
+        |> Enum.map(fn condition_data ->
+          {condition_data.upstream_node.node_name, condition_data.upstream_node.ex_revision}
+        end)
+        |> Enum.into(%{})
 
-        node_and_revisions ->
-          node_and_revisions
-          |> Enum.map(fn {k, v} ->
-            {String.to_atom(k), v}
-          end)
-          |> Enum.into(%{})
-      end
+      # Compute nodes used to compute the previous value, if any
+      computed_with_node_revisions = atomize_map_keys(computation.computed_with)
 
-    any_new_versions? =
-      computed_with_node_revisions
-      |> Enum.any?(fn {upstream_node_name, computed_with_revision} ->
-        current_node_revisions[upstream_node_name] != nil and
-          current_node_revisions[upstream_node_name] > computed_with_revision
-      end)
+      # Do any nodes used for previous computation have a newer revision?
+      any_updated_versions? =
+        computed_with_node_revisions
+        |> Enum.any?(fn {upstream_node_name, computed_with_revision} ->
+          current_node_revisions[upstream_node_name] != nil and
+            current_node_revisions[upstream_node_name] > computed_with_revision
+        end)
 
-    any_new_versions?
+      # Are there any newly met upstream dependencies?
+      any_new_nodes? =
+        current_node_revisions
+        |> Enum.any?(fn {upstream_node_name, _revision} ->
+          not Map.has_key?(computed_with_node_revisions, upstream_node_name)
+        end)
+
+      any_updated_versions? or any_new_nodes?
+    else
+      false
+    end
+  end
+
+  defp atomize_map_keys(nil), do: %{}
+
+  defp atomize_map_keys(m) when is_map(m) do
+    m
+    |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
+    |> Enum.into(%{})
   end
 end

--- a/test/journey/scheduler/abandoned_with_retries_test.exs
+++ b/test/journey/scheduler/abandoned_with_retries_test.exs
@@ -8,7 +8,10 @@ defmodule Journey.Scheduler.AbandonedWithRetriesTest do
     async: true,
     parameterize:
       for(
-        timeout_type <- [:timeout, :failure_after_timeout],
+        timeout_type <- [
+          :timeout,
+          :failure_after_timeout
+        ],
         do: %{timeout_type: timeout_type}
       )
 

--- a/test/journey/scheduler/or_recompute_comprehensive_test.exs
+++ b/test/journey/scheduler/or_recompute_comprehensive_test.exs
@@ -1,0 +1,376 @@
+defmodule Journey.Scheduler.OrRecomputeComprehensiveTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Helpers.Random, only: [random_string: 0]
+  import Journey.Node
+  import Journey.Node.Conditions
+  import Journey.Node.UpstreamDependencies
+
+  describe "OR condition recomputation" do
+    test "basic OR - setting second input triggers recomputation" do
+      g =
+        Journey.new_graph("or basic #{random_string()}", random_string(), [
+          input(:a),
+          input(:b),
+          compute(
+            :a_or_b,
+            unblocked_when({
+              :or,
+              [
+                {:a, &provided?/1},
+                {:b, &provided?/1}
+              ]
+            }),
+            fn x ->
+              {:ok, Map.get(x, :a, "_") <> Map.get(x, :b, "_")}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set first input - should compute with placeholder for b
+      e = Journey.set(e, :a, "a")
+      {:ok, result, _} = Journey.get(e, :a_or_b, wait: :any)
+      assert result == "a_"
+
+      # Set second input - should recompute with both values
+      e = Journey.set(e, :b, "b")
+      {:ok, result, _} = Journey.get(e, :a_or_b, wait: :newer)
+      assert result == "ab"
+    end
+
+    test "three-way OR - sequential sets trigger recomputation each time" do
+      g =
+        Journey.new_graph("or three-way #{random_string()}", random_string(), [
+          input(:a),
+          input(:b),
+          input(:c),
+          compute(
+            :a_or_b_or_c,
+            unblocked_when({
+              :or,
+              [
+                {:a, &provided?/1},
+                {:b, &provided?/1},
+                {:c, &provided?/1}
+              ]
+            }),
+            fn x ->
+              {:ok, Map.get(x, :a, "_") <> Map.get(x, :b, "_") <> Map.get(x, :c, "_")}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set first input
+      e = Journey.set(e, :a, "a")
+      {:ok, result, _} = Journey.get(e, :a_or_b_or_c, wait: :any)
+      assert result == "a__"
+
+      # Set second input - should recompute
+      e = Journey.set(e, :b, "b")
+      {:ok, result, _} = Journey.get(e, :a_or_b_or_c, wait: :newer)
+      assert result == "ab_"
+
+      # Set third input - should recompute again
+      e = Journey.set(e, :c, "c")
+      {:ok, result, _} = Journey.get(e, :a_or_b_or_c, wait: :newer)
+      assert result == "abc"
+    end
+
+    test "OR is order-independent - same final result regardless of set order" do
+      g =
+        Journey.new_graph("or order independent #{random_string()}", random_string(), [
+          input(:x),
+          input(:y),
+          compute(
+            :x_or_y,
+            unblocked_when({
+              :or,
+              [
+                {:x, &provided?/1},
+                {:y, &provided?/1}
+              ]
+            }),
+            fn vals ->
+              {:ok, Map.get(vals, :x, "_") <> Map.get(vals, :y, "_")}
+            end
+          )
+        ])
+
+      # Execution 1: set x then y
+      e1 = Journey.start_execution(g)
+      e1 = Journey.set(e1, :x, "X")
+      {:ok, _, _} = Journey.get(e1, :x_or_y, wait: :any)
+      e1 = Journey.set(e1, :y, "Y")
+      {:ok, result1, _} = Journey.get(e1, :x_or_y, wait: :newer)
+
+      # Execution 2: set y then x
+      e2 = Journey.start_execution(g)
+      e2 = Journey.set(e2, :y, "Y")
+      {:ok, _, _} = Journey.get(e2, :x_or_y, wait: :any)
+      e2 = Journey.set(e2, :x, "X")
+      {:ok, result2, _} = Journey.get(e2, :x_or_y, wait: :newer)
+
+      # Both should have the same final result
+      assert result1 == "XY"
+      assert result2 == "XY"
+    end
+  end
+
+  describe "AND condition behavior (control test)" do
+    test "AND conditions still work - no spurious recomputation" do
+      g =
+        Journey.new_graph("and control #{random_string()}", random_string(), [
+          input(:p),
+          input(:q),
+          compute(
+            :p_and_q,
+            [:p, :q],
+            fn %{p: p, q: q} ->
+              {:ok, "#{p}-#{q}"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set first input - should NOT compute yet (waiting for q)
+      e = Journey.set(e, :p, "P")
+      assert {:error, :not_set} = Journey.get(e, :p_and_q)
+
+      # Set second input - should compute now
+      e = Journey.set(e, :q, "Q")
+      {:ok, result, _} = Journey.get(e, :p_and_q, wait: :any)
+      assert result == "P-Q"
+
+      # Update first input - should recompute
+      e = Journey.set(e, :p, "P2")
+      {:ok, result, _} = Journey.get(e, :p_and_q, wait: :newer)
+      assert result == "P2-Q"
+    end
+  end
+
+  describe "nested conditions" do
+    test "OR inside AND - recomputes when OR branch changes" do
+      g =
+        Journey.new_graph("nested or-and #{random_string()}", random_string(), [
+          input(:a),
+          input(:b),
+          input(:c),
+          compute(
+            :nested,
+            unblocked_when({
+              :and,
+              [
+                {
+                  :or,
+                  [
+                    {:a, &provided?/1},
+                    {:b, &provided?/1}
+                  ]
+                },
+                {:c, &provided?/1}
+              ]
+            }),
+            fn vals ->
+              {:ok, "#{Map.get(vals, :a, "_")}-#{Map.get(vals, :b, "_")}-#{Map.get(vals, :c, "_")}"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set a (satisfies first branch of OR)
+      e = Journey.set(e, :a, "A")
+
+      # Set c (satisfies the AND)
+      e = Journey.set(e, :c, "C")
+      {:ok, result, _} = Journey.get(e, :nested, wait: :any)
+      assert result == "A-_-C"
+
+      # Set b (should recompute - OR has new satisfied branch)
+      e = Journey.set(e, :b, "B")
+      {:ok, result, _} = Journey.get(e, :nested, wait: :newer)
+      assert result == "A-B-C"
+    end
+
+    test "AND inside OR - complex nested conditions" do
+      g =
+        Journey.new_graph("nested and-or #{random_string()}", random_string(), [
+          input(:x),
+          input(:y),
+          input(:z),
+          compute(
+            :nested,
+            unblocked_when({
+              :or,
+              [
+                {
+                  :and,
+                  [
+                    {:x, &provided?/1},
+                    {:y, &provided?/1}
+                  ]
+                },
+                {:z, &provided?/1}
+              ]
+            }),
+            fn vals ->
+              {:ok, "#{Map.get(vals, :x, "_")}#{Map.get(vals, :y, "_")}#{Map.get(vals, :z, "_")}"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set z - satisfies OR immediately
+      e = Journey.set(e, :z, "Z")
+      {:ok, result, _} = Journey.get(e, :nested, wait: :any)
+      assert result == "__Z"
+
+      # Set x - should recompute
+      e = Journey.set(e, :x, "X")
+      {:ok, result, _} = Journey.get(e, :nested, wait: :newer)
+      assert result == "X_Z"
+
+      # Set y - should recompute again (AND branch now fully satisfied)
+      e = Journey.set(e, :y, "Y")
+      {:ok, result, _} = Journey.get(e, :nested, wait: :newer)
+      assert result == "XYZ"
+    end
+  end
+
+  describe "NOT conditions" do
+    test "NOT condition triggers recomputation when dependency changes" do
+      g =
+        Journey.new_graph("not recompute #{random_string()}", random_string(), [
+          input(:flag),
+          compute(
+            :not_flag,
+            unblocked_when({
+              :not,
+              {:flag, &provided?/1}
+            }),
+            fn _vals ->
+              {:ok, "flag_not_set"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Initially, flag is not set - should compute
+      {:ok, result, _} = Journey.get(e, :not_flag, wait: :any)
+      assert result == "flag_not_set"
+
+      # Set flag - should become unblocked (NOT is no longer satisfied)
+      # The node should be invalidated
+      e = Journey.set(e, :flag, true)
+
+      # After setting flag, the NOT condition is no longer met
+      # So the node should be unset
+      assert {:error, :not_set} = Journey.get(e, :not_flag)
+    end
+
+    test "NOT with true?/false? conditions" do
+      g =
+        Journey.new_graph("not with boolean #{random_string()}", random_string(), [
+          input(:enabled),
+          compute(
+            :when_disabled,
+            unblocked_when({
+              :not,
+              {:enabled, &true?/1}
+            }),
+            fn _vals ->
+              {:ok, "disabled"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set enabled to false - NOT should be satisfied
+      e = Journey.set(e, :enabled, false)
+      {:ok, result, _} = Journey.get(e, :when_disabled, wait: :any)
+      assert result == "disabled"
+
+      # Change enabled to true - NOT is no longer satisfied
+      e = Journey.set(e, :enabled, true)
+
+      # The node should be unset now (NOT condition no longer met)
+      assert {:error, :not_set} = Journey.get(e, :when_disabled)
+    end
+  end
+
+  describe "edge cases" do
+    test "all OR branches set simultaneously" do
+      g =
+        Journey.new_graph("or simultaneous #{random_string()}", random_string(), [
+          input(:a),
+          input(:b),
+          compute(
+            :result,
+            unblocked_when({
+              :or,
+              [
+                {:a, &provided?/1},
+                {:b, &provided?/1}
+              ]
+            }),
+            fn vals ->
+              {:ok, "#{Map.get(vals, :a, "?")}+#{Map.get(vals, :b, "?")}"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set both at once using map form
+      e = Journey.set(e, %{a: "A", b: "B"})
+      {:ok, result, _} = Journey.get(e, :result, wait: :any)
+      assert result == "A+B"
+    end
+
+    test "updating already-satisfied OR branch triggers recomputation" do
+      g =
+        Journey.new_graph("or update same branch #{random_string()}", random_string(), [
+          input(:m),
+          input(:n),
+          compute(
+            :result,
+            unblocked_when({
+              :or,
+              [
+                {:m, &provided?/1},
+                {:n, &provided?/1}
+              ]
+            }),
+            fn vals ->
+              {:ok, "m=#{Map.get(vals, :m, "?")},n=#{Map.get(vals, :n, "?")}"}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      # Set m
+      e = Journey.set(e, :m, "1")
+      {:ok, result, _} = Journey.get(e, :result, wait: :any)
+      assert result == "m=1,n=?"
+
+      # Update m again (same branch, new value)
+      e = Journey.set(e, :m, "2")
+      {:ok, result, _} = Journey.get(e, :result, wait: :newer)
+      assert result == "m=2,n=?"
+
+      # Now set n (different branch)
+      e = Journey.set(e, :n, "3")
+      {:ok, result, _} = Journey.get(e, :result, wait: :newer)
+      assert result == "m=2,n=3"
+    end
+  end
+end

--- a/test/journey/scheduler/or_recomputes_test.exs
+++ b/test/journey/scheduler/or_recomputes_test.exs
@@ -28,9 +28,11 @@ defmodule Journey.Scheduler.OrRecomputeTest do
           )
         ])
 
-      e = Journey.start_execution(g)
+      e =
+        g
+        |> Journey.start_execution()
+        |> Journey.set(:a, "a")
 
-      e = Journey.set(e, :a, "a")
       {:ok, ab, _} = Journey.get(e, :a_or_b, wait: :any)
       assert ab == "a_"
 

--- a/test/journey/scheduler/or_recomputes_test.exs
+++ b/test/journey/scheduler/or_recomputes_test.exs
@@ -37,18 +37,9 @@ defmodule Journey.Scheduler.OrRecomputeTest do
       e = Journey.load(e)
 
       Journey.set(e, :b, "b")
-      Process.sleep(1_000)
+      {:ok, ab, _} = Journey.get(e, :a_or_b, wait: :newer)
 
-      {:ok, ab, _} = Journey.get(e, :a_or_b)
       assert ab == "ab"
-
-      #      ab =
-      #        Journey.get(
-      #          e,
-      #          :a_or_b
-      # , wait: :new
-      #        )
-      #        |> IO.inspect(label: :after_b_and_wait)
     end
   end
 end

--- a/test/journey/scheduler/or_recomputes_test.exs
+++ b/test/journey/scheduler/or_recomputes_test.exs
@@ -1,0 +1,54 @@
+defmodule Journey.Scheduler.OrRecomputeTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Helpers.Random, only: [random_string: 0]
+
+  import Journey.Node
+  import Journey.Node.Conditions
+  import Journey.Node.UpstreamDependencies
+
+  describe "recompute of or conditions" do
+    test "sunny day" do
+      g =
+        Journey.new_graph("test or recomputes #{__MODULE__}", random_string(), [
+          input(:a),
+          input(:b),
+          compute(
+            :a_or_b,
+            unblocked_when({
+              :or,
+              [
+                {:a, &provided?/1},
+                {:b, &provided?/1}
+              ]
+            }),
+            fn x ->
+              {:ok, Map.get(x, :a, "_") <> Map.get(x, :b, "_")}
+            end
+          )
+        ])
+
+      e = Journey.start_execution(g)
+
+      e = Journey.set(e, :a, "a")
+      {:ok, ab, _} = Journey.get(e, :a_or_b, wait: :any)
+      assert ab == "a_"
+
+      e = Journey.load(e)
+
+      Journey.set(e, :b, "b")
+      Process.sleep(1_000)
+
+      {:ok, ab, _} = Journey.get(e, :a_or_b)
+      assert ab == "ab"
+
+      #      ab =
+      #        Journey.get(
+      #          e,
+      #          :a_or_b
+      # , wait: :new
+      #        )
+      #        |> IO.inspect(label: :after_b_and_wait)
+    end
+  end
+end


### PR DESCRIPTION
with this change, if any of the upstream nodes of an :or condition get a new revision, the node will recompute.

see the basic test in `test/journey/scheduler/or_recomputes_test.exs` for the new behavior. before this change, the test would fail -- updating `:b` would not cause a recompute of `:a_or_b` because it has already been computed with `:a`, and `:a`'s value is unchanged.