### PR TITLE
preserve downstream values when `schedule_recurring` pauses

### DIFF
--- a/lib/journey/node/upstream_dependencies/computations.ex
+++ b/lib/journey/node/upstream_dependencies/computations.ex
@@ -21,43 +21,54 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
     [upstream_node_name]
   end
 
-  def unblocked?(all_executions_values, gated_by) when is_list(all_executions_values) do
-    r = evaluate_computation_for_readiness(all_executions_values, gated_by)
+  def unblocked?(all_executions_values, gated_by, mode) when is_list(all_executions_values) do
+    r = evaluate_computation_for_readiness(all_executions_values, gated_by, mode)
     r.ready?
   end
 
-  def upstream_nodes_and_functions(node_names) when is_list(node_names) do
-    upstream_nodes_and_functions({:and, Enum.map(node_names, fn name -> {name, &provided?/1} end)})
+  # For invalidation purposes: a node is considered "provided" if it has been set,
+  # regardless of its value. This preserves downstream values when schedule nodes
+  # are paused (value=0) rather than invalidating them.
+  defp provided_for_invalidation?(value_node), do: value_node.set_time != nil
+
+  def upstream_nodes_and_functions(condition_spec, mode \\ :computation)
+
+  def upstream_nodes_and_functions(node_names, mode) when is_list(node_names) do
+    condition_fn = if mode == :invalidation, do: &provided_for_invalidation?/1, else: &provided?/1
+    upstream_nodes_and_functions({:and, Enum.map(node_names, fn name -> {name, condition_fn} end)}, mode)
   end
 
-  def upstream_nodes_and_functions({:not, {node_name, f_condition}})
+  def upstream_nodes_and_functions({:not, {node_name, f_condition}}, _mode)
       when is_atom(node_name) and is_function(f_condition, 1) do
     [{node_name, f_condition}]
   end
 
-  def upstream_nodes_and_functions({operation, conditions}) when operation in [:and, :or] and is_list(conditions) do
+  def upstream_nodes_and_functions({operation, conditions}, mode)
+      when operation in [:and, :or] and is_list(conditions) do
     conditions
-    |> Enum.flat_map(fn c -> upstream_nodes_and_functions(c) end)
+    |> Enum.flat_map(fn c -> upstream_nodes_and_functions(c, mode) end)
   end
 
-  def upstream_nodes_and_functions({upstream_node_name, f_condition})
+  def upstream_nodes_and_functions({upstream_node_name, f_condition}, _mode)
       when is_atom(upstream_node_name) and is_function(f_condition, 1) do
     [{upstream_node_name, f_condition}]
   end
 
-  def evaluate_computation_for_readiness(all_executions_values, list_of_required_node_names)
+  def evaluate_computation_for_readiness(all_executions_values, conditions, mode \\ :computation)
+
+  def evaluate_computation_for_readiness(all_executions_values, list_of_required_node_names, mode)
       when is_list(list_of_required_node_names) do
     conditions =
       list_of_required_node_names
       |> Journey.Node.UpstreamDependencies.unblocked_when()
 
-    evaluate_computation_for_readiness(all_executions_values, conditions)
+    evaluate_computation_for_readiness(all_executions_values, conditions, mode)
   end
 
-  def evaluate_computation_for_readiness(all_executions_values, {:or, conditions}) when is_list(conditions) do
+  def evaluate_computation_for_readiness(all_executions_values, {:or, conditions}, mode) when is_list(conditions) do
     results =
       conditions
-      |> Enum.map(fn c -> evaluate_computation_for_readiness(all_executions_values, c) end)
+      |> Enum.map(fn c -> evaluate_computation_for_readiness(all_executions_values, c, mode) end)
 
     any_met = Enum.any?(results, fn r -> r.ready? end)
 
@@ -73,10 +84,10 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
     }
   end
 
-  def evaluate_computation_for_readiness(all_executions_values, {:and, conditions}) when is_list(conditions) do
+  def evaluate_computation_for_readiness(all_executions_values, {:and, conditions}, mode) when is_list(conditions) do
     results =
       conditions
-      |> Enum.map(fn c -> evaluate_computation_for_readiness(all_executions_values, c) end)
+      |> Enum.map(fn c -> evaluate_computation_for_readiness(all_executions_values, c, mode) end)
 
     all_met = Enum.all?(results, fn c -> c.ready? end)
 
@@ -92,7 +103,7 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
     }
   end
 
-  def evaluate_computation_for_readiness(all_executions_values, {upstream_node_name, f_condition})
+  def evaluate_computation_for_readiness(all_executions_values, {upstream_node_name, f_condition}, mode)
       when is_atom(upstream_node_name) and is_function(f_condition, 1) do
     relevant_value_node =
       all_executions_values
@@ -102,7 +113,16 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       raise "missing value node for #{upstream_node_name}"
     end
 
-    condition_met = f_condition.(relevant_value_node)
+    # In invalidation mode, use relaxed criteria for schedule nodes only
+    # (just check if set_time != nil, regardless of value)
+    # For all other nodes, use the actual condition function
+    condition_met =
+      if mode == :invalidation and relevant_value_node.node_type in [:schedule_once, :schedule_recurring] do
+        provided_for_invalidation?(relevant_value_node)
+      else
+        f_condition.(relevant_value_node)
+      end
+
     condition_data = %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}
 
     %{
@@ -117,7 +137,7 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
     }
   end
 
-  def evaluate_computation_for_readiness(all_executions_values, {:not, {upstream_node_name, f_condition}})
+  def evaluate_computation_for_readiness(all_executions_values, {:not, {upstream_node_name, f_condition}}, mode)
       when is_atom(upstream_node_name) and is_function(f_condition, 1) do
     relevant_value_node =
       all_executions_values
@@ -127,7 +147,15 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       raise "missing value node for #{upstream_node_name}"
     end
 
-    inner_condition_met = f_condition.(relevant_value_node)
+    # In invalidation mode, use relaxed criteria for schedule nodes only
+    # For all other nodes, use the actual condition function
+    inner_condition_met =
+      if mode == :invalidation and relevant_value_node.node_type in [:schedule_once, :schedule_recurring] do
+        provided_for_invalidation?(relevant_value_node)
+      else
+        f_condition.(relevant_value_node)
+      end
+
     negated_condition_met = not inner_condition_met
     condition_data = %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :negated}
 

--- a/lib/journey/scheduler/invalidate.ex
+++ b/lib/journey/scheduler/invalidate.ex
@@ -97,7 +97,7 @@ defmodule Journey.Scheduler.Invalidate do
   end
 
   defp should_clear?(all_values, graph_node) do
-    not UpstreamDependencies.Computations.unblocked?(all_values, graph_node.gated_by)
+    not UpstreamDependencies.Computations.unblocked?(all_values, graph_node.gated_by, :invalidation)
   end
 
   defp clear_discardable_computation(execution_id, node_name, graph_node, repo, prefix) do

--- a/lib/journey/scheduler/recompute.ex
+++ b/lib/journey/scheduler/recompute.ex
@@ -9,7 +9,7 @@ defmodule Journey.Scheduler.Recompute do
   alias Journey.Persistence.Schema.Execution.Computation
   alias Journey.Persistence.Schema.Execution.Value
 
-  import Journey.Node.UpstreamDependencies.Computations, only: [unblocked?: 2]
+  import Journey.Node.UpstreamDependencies.Computations, only: [unblocked?: 3]
 
   # Namespace for PostgreSQL advisory locks used to prevent duplicate re-computations
   @advance_lock_namespace 54_321
@@ -49,7 +49,9 @@ defmodule Journey.Scheduler.Recompute do
           all_computations
           # credo:disable-for-lines:15 Credo.Check.Refactor.FilterFilter
           |> Enum.filter(fn c -> an_upstream_node_has_a_newer_version?(c, graph, all_values) end)
-          |> Enum.filter(fn c -> unblocked?(all_values, Graph.find_node_by_name(graph, c.node_name).gated_by) end)
+          |> Enum.filter(fn c ->
+            unblocked?(all_values, Graph.find_node_by_name(graph, c.node_name).gated_by, :computation)
+          end)
           |> Enum.reject(fn c -> has_pending_computation?(execution.id, c.node_name, repo) end)
           |> Enum.map(fn computation_to_re_create ->
             new_computation =

--- a/test/journey/scheduler/paused_schedule_invalidation_test.exs
+++ b/test/journey/scheduler/paused_schedule_invalidation_test.exs
@@ -1,0 +1,236 @@
+defmodule Journey.Scheduler.PausedScheduleInvalidationTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Node
+  import Journey.Test.Support.Helpers
+
+  import Journey.Scheduler.Background.Periodic,
+    only: [start_background_sweeps_in_test: 1, stop_background_sweeps_in_test: 1]
+
+  @moduletag timeout: 60_000
+
+  describe "invalidation with paused schedule_recurring" do
+    test "paused schedule + valid other dependency - should NOT clear downstream" do
+      graph =
+        Journey.new_graph(
+          "paused schedule with valid dep test #{__MODULE__}",
+          "1.0.0",
+          [
+            input(:user_config),
+            input(:enable_schedule),
+            schedule_recurring(
+              :schedule_pulse,
+              [:enable_schedule],
+              fn %{enable_schedule: enabled} ->
+                if enabled do
+                  {:ok, System.system_time(:second) + 2}
+                else
+                  {:ok, 0}
+                end
+              end
+            ),
+            compute(
+              :process_data,
+              [:user_config, :schedule_pulse],
+              fn %{user_config: config} = v ->
+                count = Map.get(v, :process_data, 0) + 1
+                {:ok, "#{config}-#{count}"}
+              end
+            )
+          ]
+        )
+
+      execution = Journey.start_execution(graph)
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Start with schedule enabled and config set
+      execution = Journey.set(execution, :user_config, "v1")
+      execution = Journey.set(execution, :enable_schedule, true)
+
+      # Wait for first execution
+      assert wait_for_value(execution, :process_data, "v1-1", timeout: 10_000)
+
+      # Pause the schedule
+      execution = Journey.set(execution, :enable_schedule, false)
+      assert {:ok, 0, _} = Journey.get(execution, :schedule_pulse, wait: :newer)
+
+      # Reload to get latest state
+      execution = Journey.load(execution)
+
+      # CRITICAL: process_data should still have its value (user_config is still valid)
+      assert {:ok, "v1-1", _} = Journey.get(execution, :process_data),
+             "Downstream should keep value when schedule pauses but other deps remain valid"
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "paused schedule + invalid other dependency - SHOULD clear downstream" do
+      graph =
+        Journey.new_graph(
+          "paused schedule with invalid dep test #{__MODULE__}",
+          "1.0.0",
+          [
+            input(:user_config),
+            input(:enable_schedule),
+            schedule_recurring(
+              :schedule_pulse,
+              [:enable_schedule],
+              fn %{enable_schedule: enabled} ->
+                if enabled do
+                  {:ok, System.system_time(:second) + 2}
+                else
+                  {:ok, 0}
+                end
+              end
+            ),
+            compute(
+              :process_data,
+              [:user_config, :schedule_pulse],
+              fn %{user_config: config} = v ->
+                count = Map.get(v, :process_data, 0) + 1
+                {:ok, "#{config}-#{count}"}
+              end
+            )
+          ]
+        )
+
+      execution = Journey.start_execution(graph)
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Start with schedule enabled and config set
+      execution = Journey.set(execution, :user_config, "v1")
+      execution = Journey.set(execution, :enable_schedule, true)
+
+      # Wait for first execution
+      assert wait_for_value(execution, :process_data, "v1-1", timeout: 10_000)
+
+      # Pause schedule AND unset config
+      execution = Journey.set(execution, :enable_schedule, false)
+      execution = Journey.unset(execution, :user_config)
+
+      # Reload to get latest state
+      execution = Journey.load(execution)
+
+      # CRITICAL: process_data should be cleared (user_config is invalid)
+      assert {:error, :not_set} = Journey.get(execution, :process_data),
+             "Downstream should be cleared when other dependency becomes invalid, even if schedule is paused"
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "paused schedule as only dependency - should NOT clear downstream" do
+      # This is the main scenario from the failing test
+      graph =
+        Journey.new_graph(
+          "paused schedule only dep test #{__MODULE__}",
+          "1.0.0",
+          [
+            input(:enable_schedule),
+            schedule_recurring(
+              :schedule_pulse,
+              [:enable_schedule],
+              fn %{enable_schedule: enabled} ->
+                if enabled do
+                  {:ok, System.system_time(:second) + 2}
+                else
+                  {:ok, 0}
+                end
+              end
+            ),
+            compute(
+              :counter,
+              [:schedule_pulse],
+              fn v ->
+                count = Map.get(v, :counter, 0) + 1
+                {:ok, count}
+              end
+            )
+          ]
+        )
+
+      execution = Journey.start_execution(graph)
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Start with schedule enabled
+      execution = Journey.set(execution, :enable_schedule, true)
+
+      # Wait for first execution
+      assert wait_for_value(execution, :counter, 1, timeout: 10_000)
+
+      # Pause the schedule
+      execution = Journey.set(execution, :enable_schedule, false)
+      assert {:ok, 0, _} = Journey.get(execution, :schedule_pulse, wait: :newer)
+
+      # Reload to get latest state
+      execution = Journey.load(execution)
+
+      # CRITICAL: counter should still have its value
+      assert {:ok, 1, _} = Journey.get(execution, :counter),
+             "Downstream should keep accumulated value when schedule pauses"
+
+      # Wait to ensure no new executions
+      :timer.sleep(3_000)
+      execution = Journey.load(execution)
+
+      assert {:ok, 1, _} = Journey.get(execution, :counter),
+             "Counter should not increment while paused"
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "resuming paused schedule allows execution to continue" do
+      graph =
+        Journey.new_graph(
+          "resume paused schedule test #{__MODULE__}",
+          "1.0.0",
+          [
+            input(:enable_schedule),
+            schedule_recurring(
+              :schedule_pulse,
+              [:enable_schedule],
+              fn %{enable_schedule: enabled} ->
+                if enabled do
+                  {:ok, System.system_time(:second) + 2}
+                else
+                  {:ok, 0}
+                end
+              end
+            ),
+            compute(
+              :counter,
+              [:schedule_pulse],
+              fn v ->
+                count = Map.get(v, :counter, 0) + 1
+                {:ok, count}
+              end
+            )
+          ]
+        )
+
+      execution = Journey.start_execution(graph)
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Start with schedule enabled
+      execution = Journey.set(execution, :enable_schedule, true)
+      assert wait_for_value(execution, :counter, 1, timeout: 10_000)
+
+      # Pause
+      execution = Journey.set(execution, :enable_schedule, false)
+      assert {:ok, 0, _} = Journey.get(execution, :schedule_pulse, wait: :newer)
+
+      # Verify counter is preserved
+      execution = Journey.load(execution)
+      {:ok, paused_count, _} = Journey.get(execution, :counter)
+      assert paused_count >= 1
+
+      # Resume
+      execution = Journey.set(execution, :enable_schedule, true)
+
+      # Verify execution continues from where it left off
+      assert wait_for_value(execution, :counter, paused_count + 1, timeout: 10_000),
+             "Counter should continue incrementing from paused value after resume"
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+  end
+end

--- a/test/journey/tools/computation_status_as_text_test.exs
+++ b/test/journey/tools/computation_status_as_text_test.exs
@@ -272,7 +272,7 @@ defmodule Journey.Tools.ComputationStatusAsTextTest do
       # We'll check that it matches one of the expected patterns
       #
       expected_set_list =
-        [3, 5, 7]
+        [3, 5, 7, 9]
         |> Enum.map(fn rev ->
           """
           :recurring_task (CMPREDACTED): ✅ :success | :schedule_recurring | rev #{rev}


### PR DESCRIPTION
following up on https://github.com/markmark206/journey/pull/200 – splitting semantics of "blocking downstream computations" vs "requiring invalidating downstream values."