### PR TITLE
mutate(): adding `update_revision` option to optionally trigger downstream re-computations

### DIFF
--- a/MODULES_AND_FUNCTIONS.md
+++ b/MODULES_AND_FUNCTIONS.md
@@ -31,7 +31,7 @@ Functions for creating various types of nodes in a graph.
 Functions:
 - `Journey.Node.input/1` - Creates a graph input node whose value is set with `Journey.set/3` or `Journey.set/2`
 - `Journey.Node.compute/4` - Creates a self-computing node that calculates its value based on upstream dependencies, when unblocked
-- `Journey.Node.mutate/4` - Creates a graph node that mutates the value of another node, when unblocked
+- `Journey.Node.mutate/4` - Creates a graph node that mutates the value of another node, when unblocked (optionally triggers downstream recomputation with `update_revision: true`)
 - `Journey.Node.historian/3` - EXPERIMENTAL: Creates a history-tracking node that maintains a chronological log of changes to another node (default limit: 1000 entries)
 - `Journey.Node.archive/3` - Creates a graph node that archives data when unblocked
 - `Journey.Node.schedule_once/4` - Creates a graph node that declares its readiness at a specific time, once

--- a/lib/journey/graph/step.ex
+++ b/lib/journey/graph/step.ex
@@ -1,7 +1,17 @@
 defmodule Journey.Graph.Step do
   @moduledoc false
 
-  defstruct [:name, :gated_by, :f_compute, :f_on_save, :type, :mutates, :max_retries, :abandon_after_seconds]
+  defstruct [
+    :name,
+    :gated_by,
+    :f_compute,
+    :f_on_save,
+    :type,
+    :mutates,
+    :update_revision,
+    :max_retries,
+    :abandon_after_seconds
+  ]
 
   @type t :: %__MODULE__{
           name: atom,
@@ -10,6 +20,7 @@ defmodule Journey.Graph.Step do
           f_on_save: function | nil,
           type: Journey.Persistence.Schema.Execution.ComputationType.t(),
           mutates: atom | nil,
+          update_revision: boolean,
           max_retries: pos_integer(),
           abandon_after_seconds: pos_integer()
         }

--- a/lib/journey/graph/validations.ex
+++ b/lib/journey/graph/validations.ex
@@ -114,6 +114,10 @@ defmodule Journey.Graph.Validations do
       raise "Mutation node '#{inspect(step.name)}' attempts to mutate itself"
     end
 
+    if not is_nil(step.mutates) and step.update_revision and MapSet.member?(all_upstream_node_names, step.mutates) do
+      raise "Mutation node '#{inspect(step.name)}' with update_revision: true creates a cycle by mutating '#{inspect(step.mutates)}' which is in its upstream dependencies"
+    end
+
     step
   end
 

--- a/lib/journey/scheduler/completions.ex
+++ b/lib/journey/scheduler/completions.ex
@@ -149,6 +149,7 @@ defmodule Journey.Scheduler.Completions do
           record_result(
             repo,
             graph_node.mutates,
+            false,
             computation.node_name,
             computation.execution_id,
             new_revision,
@@ -159,6 +160,7 @@ defmodule Journey.Scheduler.Completions do
           record_result(
             repo,
             graph_node.mutates,
+            graph_node.update_revision,
             computation.node_name,
             computation.execution_id,
             new_revision,
@@ -169,6 +171,7 @@ defmodule Journey.Scheduler.Completions do
           record_result(
             repo,
             graph_node.mutates,
+            false,
             computation.node_name,
             computation.execution_id,
             new_revision,
@@ -179,6 +182,7 @@ defmodule Journey.Scheduler.Completions do
           record_result(
             repo,
             graph_node.mutates,
+            false,
             computation.node_name,
             computation.execution_id,
             new_revision,
@@ -207,7 +211,7 @@ defmodule Journey.Scheduler.Completions do
     end
   end
 
-  defp record_result(repo, node_to_mutate, node_name, execution_id, new_revision, result)
+  defp record_result(repo, node_to_mutate, _update_revision, node_name, execution_id, new_revision, result)
        when is_nil(node_to_mutate) do
     # Record the result in the corresponding value node.
     set_value(
@@ -219,7 +223,7 @@ defmodule Journey.Scheduler.Completions do
     )
   end
 
-  defp record_result(repo, node_to_mutate, node_name, execution_id, new_revision, result) do
+  defp record_result(repo, node_to_mutate, update_revision, node_name, execution_id, new_revision, result) do
     # Update this node to note that the mutation has been computed.
     set_value(
       execution_id,
@@ -230,12 +234,14 @@ defmodule Journey.Scheduler.Completions do
     )
 
     # Record the result in the value node being mutated.
-    # Note that mutations are not regular updates, and do not trigger a recomputation,
-    # so we don't update the value's revision.
+    # If update_revision is true, update the revision to trigger downstream recomputation.
+    # Otherwise, don't update the revision (mutations don't trigger recomputation by default).
+    mutated_node_revision = if update_revision, do: new_revision, else: nil
+
     set_value(
       execution_id,
       node_to_mutate,
-      nil,
+      mutated_node_revision,
       repo,
       result
     )

--- a/test/journey/graph/validations_test.exs
+++ b/test/journey/graph/validations_test.exs
@@ -1,0 +1,128 @@
+defmodule Journey.Graph.ValidationsTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Node
+
+  describe "mutate with update_revision cycle detection |" do
+    test "mutate with update_revision: true mutating an upstream node raises error" do
+      assert_raise RuntimeError,
+                   ~r/Mutation node ':normalize_value' with update_revision: true creates a cycle by mutating ':value' which is in its upstream dependencies/,
+                   fn ->
+                     Journey.new_graph(
+                       "invalid cycle graph",
+                       "v1.0.0",
+                       [
+                         input(:value),
+                         mutate(
+                           :normalize_value,
+                           [:value],
+                           fn %{value: v} -> {:ok, String.downcase(v)} end,
+                           mutates: :value,
+                           update_revision: true
+                         )
+                       ]
+                     )
+                   end
+    end
+
+    test "mutate with update_revision: false mutating an upstream node is allowed" do
+      # This should not raise - mutations without update_revision can mutate upstream nodes
+      graph =
+        Journey.new_graph(
+          "valid mutation of upstream",
+          "v1.0.0",
+          [
+            input(:value),
+            mutate(
+              :change_value,
+              [:value],
+              fn %{value: _v} -> {:ok, "changed"} end,
+              mutates: :value,
+              update_revision: false
+            )
+          ]
+        )
+
+      assert graph != nil
+    end
+
+    test "mutate with update_revision: true mutating a non-upstream node is allowed" do
+      # This should not raise - the mutated node is not in upstream dependencies
+      graph =
+        Journey.new_graph(
+          "valid mutation of non-upstream",
+          "v1.0.0",
+          [
+            input(:trigger),
+            input(:target),
+            mutate(
+              :update_target,
+              [:trigger],
+              fn _ -> {:ok, "updated"} end,
+              mutates: :target,
+              update_revision: true
+            )
+          ]
+        )
+
+      assert graph != nil
+    end
+
+    test "mutate with update_revision: true in a chain (schedule + mutate + compute) is valid" do
+      # The rideshare pattern should be valid
+      graph =
+        Journey.new_graph(
+          "rideshare location pattern",
+          "v1.0.0",
+          [
+            schedule_recurring(
+              :location_schedule,
+              [],
+              fn _ -> {:ok, System.system_time(:second) + 5} end
+            ),
+            input(:driver_location),
+            mutate(
+              :update_location,
+              [:location_schedule],
+              fn %{driver_location: loc} -> {:ok, (loc || 0) + 1} end,
+              mutates: :driver_location,
+              update_revision: true
+            ),
+            compute(
+              :eta,
+              [:driver_location],
+              fn %{driver_location: loc} -> {:ok, "ETA: #{100 - loc} min"} end
+            )
+          ]
+        )
+
+      assert graph != nil
+    end
+
+    test "complex upstream dependency chain with cycle detection" do
+      assert_raise RuntimeError,
+                   ~r/Mutation node ':mutate_b' with update_revision: true creates a cycle by mutating ':value_b' which is in its upstream dependencies/,
+                   fn ->
+                     Journey.new_graph(
+                       "complex cycle",
+                       "v1.0.0",
+                       [
+                         input(:value_a),
+                         compute(
+                           :value_b,
+                           [:value_a],
+                           fn %{value_a: a} -> {:ok, a * 2} end
+                         ),
+                         mutate(
+                           :mutate_b,
+                           [:value_b],
+                           fn %{value_b: b} -> {:ok, b + 1} end,
+                           mutates: :value_b,
+                           update_revision: true
+                         )
+                       ]
+                     )
+                   end
+    end
+  end
+end

--- a/test/journey/scheduler/mutate_update_revision_test.exs
+++ b/test/journey/scheduler/mutate_update_revision_test.exs
@@ -1,0 +1,247 @@
+defmodule Journey.Scheduler.MutateUpdateRevisionTest do
+  use ExUnit.Case, async: true
+
+  require Logger
+  import Journey.Node
+
+  describe "mutate with update_revision |" do
+    test "mutate with update_revision: true triggers downstream recomputation" do
+      graph =
+        Journey.new_graph(
+          "mutate update_revision true test",
+          "v1.0.0",
+          [
+            input(:trigger),
+            input(:temperature),
+            mutate(
+              :update_temperature,
+              [:trigger],
+              fn %{temperature: temp} ->
+                # Update temperature from external source
+                {:ok, (temp || 20) + 10}
+              end,
+              mutates: :temperature,
+              update_revision: true
+            ),
+            compute(
+              :temperature_alert,
+              [:temperature],
+              fn %{temperature: temp} ->
+                if temp > 30 do
+                  {:ok, "High temperature: #{temp}°C"}
+                else
+                  {:ok, "Normal temperature: #{temp}°C"}
+                end
+              end
+            )
+          ]
+        )
+
+      execution = graph |> Journey.start_execution()
+
+      # Set initial temperature and trigger
+      execution = Journey.set(execution, :temperature, 20)
+      execution = Journey.set(execution, :trigger, 1)
+
+      # Wait for mutation to complete
+      {:ok, "updated :temperature", _} = Journey.get(execution, :update_temperature, wait: :any)
+
+      # Temperature alert should compute with the mutated value (30)
+      {:ok, "Normal temperature: 30°C", _} = Journey.get(execution, :temperature_alert, wait: :any)
+
+      # Trigger another update
+      execution = Journey.set(execution, :trigger, 2)
+
+      # Wait for mutation to complete
+      {:ok, "updated :temperature", _} = Journey.get(execution, :update_temperature, wait: :newer)
+
+      # Temperature alert should RECOMPUTE because update_revision: true
+      {:ok, "High temperature: 40°C", _} = Journey.get(execution, :temperature_alert, wait: :newer)
+    end
+
+    test "mutate with update_revision: false (default) does NOT trigger downstream recomputation" do
+      graph =
+        Journey.new_graph(
+          "mutate update_revision false test",
+          "v1.0.0",
+          [
+            input(:trigger),
+            input(:value),
+            mutate(
+              :change_value,
+              [:trigger],
+              fn _ ->
+                {:ok, "mutated"}
+              end,
+              mutates: :value,
+              update_revision: false
+            ),
+            compute(
+              :downstream,
+              [:value],
+              fn %{value: v} ->
+                {:ok, "computed with: #{v}"}
+              end
+            )
+          ]
+        )
+
+      execution = graph |> Journey.start_execution()
+
+      # Set trigger first to cause mutation
+      execution = Journey.set(execution, :trigger, 1)
+      execution = Journey.set(execution, :value, "original")
+
+      # Wait for mutation to complete - it will mutate value to "mutated"
+      {:ok, "updated :value", _} = Journey.get(execution, :change_value, wait: :any)
+
+      # Downstream computes with the mutated value
+      {:ok, "computed with: mutated", rev1} = Journey.get(execution, :downstream, wait: :any)
+
+      # Trigger another mutation
+      execution = Journey.set(execution, :trigger, 2)
+
+      # Wait for mutation to complete
+      {:ok, "updated :value", _} = Journey.get(execution, :change_value, wait: :newer)
+
+      # Downstream should NOT recompute - revision should be the same
+      {:ok, "computed with: mutated", ^rev1} = Journey.get(execution, :downstream)
+    end
+
+    test "external polling pattern: schedule_recurring + mutate + compute downstream" do
+      graph =
+        Journey.new_graph(
+          "external polling pattern test",
+          "v1.0.0",
+          [
+            schedule_recurring(
+              :location_poll_schedule,
+              [],
+              fn _ ->
+                # Schedule every 2 seconds
+                {:ok, System.system_time(:second) + 2}
+              end
+            ),
+            input(:driver_location),
+            mutate(
+              :update_location_from_gps,
+              [:location_poll_schedule],
+              fn %{driver_location: current_location} ->
+                # Simulate fetching from GPS - increment location
+                new_location = (current_location || 0) + 10
+                {:ok, new_location}
+              end,
+              mutates: :driver_location,
+              update_revision: true
+            ),
+            compute(
+              :arrival_eta,
+              [:driver_location],
+              fn %{driver_location: location} ->
+                # Calculate ETA based on distance (destination at 100)
+                distance = 100 - location
+                eta_minutes = max(0, div(distance, 10))
+                {:ok, "ETA: #{eta_minutes} minutes"}
+              end
+            )
+          ]
+        )
+
+      execution = graph |> Journey.start_execution()
+
+      # Start background sweeps for scheduled nodes
+      background_sweeps_task =
+        Journey.Scheduler.Background.Periodic.start_background_sweeps_in_test(execution.id)
+
+      # Set initial location
+      execution = Journey.set(execution, :driver_location, 0)
+
+      # Wait for schedule to fire and trigger first mutation
+      {:ok, "updated :driver_location", rev1} =
+        Journey.get(execution, :update_location_from_gps, wait: :any)
+
+      # ETA should recompute after mutation (location becomes 10)
+      {:ok, eta1, _} = Journey.get(execution, :arrival_eta, wait: :newer)
+      # After mutation: location = 10, ETA = (100-10)/10 = 9 minutes
+      assert eta1 == "ETA: 9 minutes"
+
+      # Wait for scheduled update to trigger mutation (must be newer than rev1)
+      {:ok, "updated :driver_location", rev2} =
+        Journey.get(execution, :update_location_from_gps, wait: {:newer_than, rev1})
+
+      assert rev2 > rev1
+
+      # ETA should recompute with new location (20), ETA = (100-20)/10 = 8 minutes
+      {:ok, eta2, _} = Journey.get(execution, :arrival_eta, wait: :newer)
+      assert eta2 == "ETA: 8 minutes"
+
+      Journey.Scheduler.Background.Periodic.stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "multiple downstream nodes all recompute when mutation with update_revision occurs" do
+      graph =
+        Journey.new_graph(
+          "multiple downstream test",
+          "v1.0.0",
+          [
+            input(:trigger),
+            input(:price),
+            mutate(
+              :apply_discount,
+              [:trigger],
+              fn %{price: p} ->
+                {:ok, p * 0.9}
+              end,
+              mutates: :price,
+              update_revision: true
+            ),
+            compute(
+              :price_with_tax,
+              [:price],
+              fn %{price: p} ->
+                {:ok, p * 1.1}
+              end
+            ),
+            compute(
+              :price_display,
+              [:price],
+              fn %{price: p} ->
+                {:ok, "$#{Float.round(p, 2)}"}
+              end
+            )
+          ]
+        )
+
+      execution = graph |> Journey.start_execution()
+
+      # Set initial price and trigger
+      execution = Journey.set(execution, :price, 100.0)
+      execution = Journey.set(execution, :trigger, 1)
+
+      # Wait for mutation
+      {:ok, "updated :price", _} = Journey.get(execution, :apply_discount, wait: :any)
+
+      # Wait for both downstream computations
+      {:ok, price_with_tax1, _} = Journey.get(execution, :price_with_tax, wait: :any)
+      {:ok, price_display1, _} = Journey.get(execution, :price_display, wait: :any)
+
+      # Verify they computed with the discounted price (90)
+      assert_in_delta price_with_tax1, 99.0, 0.01
+      assert price_display1 == "$90.0"
+
+      # Trigger another discount
+      execution = Journey.set(execution, :trigger, 2)
+
+      # Wait for mutation
+      {:ok, "updated :price", _} = Journey.get(execution, :apply_discount, wait: :newer)
+
+      # Both downstream should recompute
+      {:ok, price_with_tax2, _} = Journey.get(execution, :price_with_tax, wait: :newer)
+      {:ok, price_display2, _} = Journey.get(execution, :price_display, wait: :newer)
+
+      # Verify they computed with the newly discounted price (90 * 0.9 = 81)
+      assert_in_delta price_with_tax2, 89.1, 0.01
+      assert price_display2 == "$81.0"
+    end
+  end
+end


### PR DESCRIPTION
a common patten is to have a recurring computation call some api (current weather, user location, etc) and update a graph's input node with the fetched value, triggering downstream processing (e.g. lowering shades if sunny / hot, sending the passenger a notification when the driver is nearby).

this allows for the recurring computation to mutate() the input node, in a way that causes downstream computations to take place (this removes the need for the recurring computation to have to explicitly call set(), without the benefit of graph circle detection safeguards).