### PR TITLE
docs: *very* soft-deprecating `Journey.get_value()`

### DIFF
--- a/lib/journey.ex
+++ b/lib/journey.ex
@@ -1799,6 +1799,10 @@ defmodule Journey do
     end
   end
 
+  @doc group: "Deprecated"
+  @doc """
+    Deprecated, use `Journey.get/3` instead"
+  """
   def get_value(execution, node_name, opts \\ [])
       when is_struct(execution, Execution) and is_atom(node_name) and is_list(opts) do
     # Check for new vs old style options


### PR DESCRIPTION
Putting Journey.get_value() in the Deprecated section, and adding a "deprecated!" comment.

(Not adding an actual deprecated tag just yet, to avoid deprecation warnings for now.)